### PR TITLE
[Feat] Google 로그인 및 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/src/main/java/com/flyby/ramble/auth/filter/JwtFilter.java
+++ b/src/main/java/com/flyby/ramble/auth/filter/JwtFilter.java
@@ -1,5 +1,6 @@
-package com.flyby.ramble.jwt;
+package com.flyby.ramble.auth.filter;
 
+import com.flyby.ramble.auth.util.JwtUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/flyby/ramble/auth/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/com/flyby/ramble/auth/handler/OidcAuthenticationSuccessHandler.java
@@ -1,0 +1,51 @@
+package com.flyby.ramble.auth.handler;
+
+import com.flyby.ramble.auth.util.JwtUtil;
+import com.flyby.ramble.model.DeviceType;
+import com.flyby.ramble.model.OAuthProvider;
+import com.flyby.ramble.model.Role;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OidcAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        OidcUser oidc = (OidcUser) authentication.getPrincipal();
+        OidcIdToken idToken = oidc.getIdToken();
+
+        Map<String, Object> claims = new HashMap<>(idToken.getClaims());
+        String userId = claims.get("userId").toString();
+        String provider = claims.get("provider").toString();
+        String providerId = idToken.getSubject();
+
+        String accessToken = jwtUtil.createToken(
+                UUID.fromString(userId),
+                Role.USER,
+                DeviceType.WEB,
+                OAuthProvider.valueOf(provider),
+                providerId);
+
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/com/flyby/ramble/auth/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/com/flyby/ramble/auth/handler/OidcAuthenticationSuccessHandler.java
@@ -40,6 +40,10 @@ public class OidcAuthenticationSuccessHandler implements AuthenticationSuccessHa
         String userId = claims.get("userId").toString();
         String provider = claims.get("provider").toString();
 
+        if (userId == null || provider == null) {
+            throw new IllegalArgumentException("userId 또는 provider가 null입니다.");
+        }
+
         String accessToken = jwtUtil.createToken(
                 UUID.fromString(userId),
                 Role.USER,

--- a/src/main/java/com/flyby/ramble/auth/service/CustomOidcUserService.java
+++ b/src/main/java/com/flyby/ramble/auth/service/CustomOidcUserService.java
@@ -33,12 +33,16 @@ public class CustomOidcUserService implements OAuth2UserService<OidcUserRequest,
         Map<String, Object> claims = new HashMap<>(idToken.getClaims());
 
         String registration = userRequest.getClientRegistration().getRegistrationId();
-        OAuthProvider provider = OAuthProvider.valueOf(registration.toUpperCase());
+        OAuthProvider provider = OAuthProvider.from(registration);
         String providerId = idToken.getSubject();
-        String email = claims.get("email").toString();
-        String username = claims.get("name").toString();
+        Object email = claims.get("email");
+        Object username = claims.get("name");
 
-        User user = userService.registerOrLogin(email, username, provider, providerId);
+        if (email == null || username == null) {
+            throw new OAuth2AuthenticationException("필수 정보(email, name)가 누락되었습니다.");
+        }
+
+        User user = userService.registerOrLogin(email.toString(), username.toString(), provider, providerId);
 
         claims.put("userId", user.getExternalId());
         claims.put("provider", provider);

--- a/src/main/java/com/flyby/ramble/auth/service/CustomOidcUserService.java
+++ b/src/main/java/com/flyby/ramble/auth/service/CustomOidcUserService.java
@@ -1,0 +1,62 @@
+package com.flyby.ramble.auth.service;
+
+import com.flyby.ramble.model.OAuthProvider;
+import com.flyby.ramble.model.Role;
+import com.flyby.ramble.model.User;
+import com.flyby.ramble.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final OidcUserService oidcUserService = new OidcUserService();
+    private final UserService userService;
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = oidcUserService.loadUser(userRequest);
+
+        OidcIdToken idToken = oidcUser.getIdToken();
+        Map<String, Object> claims = new HashMap<>(idToken.getClaims());
+
+        String registration = userRequest.getClientRegistration().getRegistrationId();
+        OAuthProvider provider = OAuthProvider.valueOf(registration.toUpperCase());
+        String providerId = idToken.getSubject();
+        String email = claims.get("email").toString();
+        String username = claims.get("name").toString();
+
+        User user = userService.registerOrLogin(email, username, provider, providerId);
+
+        claims.put("userId", user.getExternalId());
+        claims.put("provider", provider);
+        claims.put("role", Role.USER);
+
+        Set<GrantedAuthority> auths = new HashSet<>(oidcUser.getAuthorities());
+        auths.add(new SimpleGrantedAuthority("ROLE_USER"));
+        OidcIdToken newIdToken = new OidcIdToken(
+            idToken.getTokenValue(),
+            idToken.getIssuedAt(),
+            idToken.getExpiresAt(),
+            claims
+        );
+
+        return new DefaultOidcUser(
+            auths,
+            newIdToken,
+            oidcUser.getUserInfo()
+        );
+    }
+}

--- a/src/main/java/com/flyby/ramble/auth/util/JwtUtil.java
+++ b/src/main/java/com/flyby/ramble/auth/util/JwtUtil.java
@@ -1,5 +1,7 @@
-package com.flyby.ramble.jwt;
+package com.flyby.ramble.auth.util;
 
+import com.flyby.ramble.model.DeviceType;
+import com.flyby.ramble.model.OAuthProvider;
 import com.flyby.ramble.model.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
@@ -56,22 +58,25 @@ public class JwtUtil {
     }
 
     public boolean isExpired(String token) {
-        return jwtParser
-                .parseSignedClaims(token)
-                .getPayload()
+        return parseClaims(token)
                 .getExpiration()
                 .before(new Date());
     }
 
-    public String createToken(UUID userId, Role role, String tenantId) {
+    public String createToken(UUID userId, Role role, DeviceType deviceType, OAuthProvider provider, String providerId) {
         Instant now = Instant.now();
         Instant expiry = now.plusMillis(expiration);
 
-        // claim이 많아지면 claims로 변경
-        // TODO: tenantId 미구현 상태
+        // claims 생성
+        Map<String, Object> claims = Map.of(
+                "role", "ROLE_" + role.name(),
+                "deviceType", deviceType.name(),
+                "provider", provider.name(),
+                "providerId", providerId
+        );
+
         return Jwts.builder()
-                .claim("role", "ROLE_" + role.name())
-                .claim("tenantId", tenantId)
+                .claims(claims)
                 .subject(userId.toString())
                 .issuer(issuer)
                 .issuedAt(Date.from(now))

--- a/src/main/java/com/flyby/ramble/auth/util/JwtUtil.java
+++ b/src/main/java/com/flyby/ramble/auth/util/JwtUtil.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.WeakKeyException;
 import jakarta.annotation.PostConstruct;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -63,11 +64,10 @@ public class JwtUtil {
                 .before(new Date());
     }
 
-    public String createToken(UUID userId, Role role, DeviceType deviceType, OAuthProvider provider, String providerId) {
+    public String createToken(@NonNull UUID userId, @NonNull Role role, @NonNull DeviceType deviceType, @NonNull OAuthProvider provider, @NonNull String providerId) {
         Instant now = Instant.now();
         Instant expiry = now.plusMillis(expiration);
 
-        // claims 생성
         Map<String, Object> claims = Map.of(
                 "role", "ROLE_" + role.name(),
                 "deviceType", deviceType.name(),

--- a/src/main/java/com/flyby/ramble/model/DeviceType.java
+++ b/src/main/java/com/flyby/ramble/model/DeviceType.java
@@ -1,0 +1,10 @@
+package com.flyby.ramble.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum DeviceType {
+    ANDROID,
+    IOS,
+    WEB
+}

--- a/src/main/java/com/flyby/ramble/model/OAuthProvider.java
+++ b/src/main/java/com/flyby/ramble/model/OAuthProvider.java
@@ -5,5 +5,15 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 @JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum OAuthProvider {
     GOOGLE,
-    APPLE
+    APPLE;
+
+    public static OAuthProvider from(String provider) {
+        for (OAuthProvider oAuthProvider : OAuthProvider.values()) {
+            if (oAuthProvider.name().equalsIgnoreCase(provider)) {
+                return oAuthProvider;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + provider);
+    }
+
 }

--- a/src/main/java/com/flyby/ramble/model/OAuthProvider.java
+++ b/src/main/java/com/flyby/ramble/model/OAuthProvider.java
@@ -3,7 +3,7 @@ package com.flyby.ramble.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 @JsonFormat(shape = JsonFormat.Shape.STRING)
-public enum Platform {
+public enum OAuthProvider {
     GOOGLE,
     APPLE
 }

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -48,14 +48,27 @@ public class User extends BaseEntity {
     @PrePersist
     public void assignExternalId() {
         if (externalId == null) {
-            externalId = UUID.randomUUID();
+            try {
+                UUID uuid = UUID.randomUUID();
+                long mostSigBits = uuid.getMostSignificantBits();
+                long leastSigBits = uuid.getLeastSignificantBits();
+
+                // 시간적 지역성을 개선하기 위한 비트 재배열
+                externalId =  new UUID(leastSigBits, mostSigBits);
+            } catch (SecurityException e) {
+                externalId = new UUID(System.currentTimeMillis(), System.nanoTime());
+            }
         }
     }
 
     @Builder
     public User(String username, String email, OAuthProvider provider, String providerId, Role role) {
-        if (username.isEmpty() || email.isEmpty() || provider == null || providerId.isEmpty()) {
+        if (username == null || email == null || provider == null || providerId == null) {
             throw new IllegalArgumentException("필수 필드는 null이 될 수 없습니다");
+        }
+
+        if (username.isEmpty() || email.isEmpty() || providerId.isEmpty()) {
+            throw new IllegalArgumentException("필수 필드는 빈 값이 될 수 없습니다");
         }
 
         this.username = username;

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -3,10 +3,17 @@ package com.flyby.ramble.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider", columnNames = "provider"),
+                @UniqueConstraint(name = "uk_provider_id", columnNames = "provider_id")
+        }
+)
 public class User extends BaseEntity {
 
     // TODO: validation 필요 (email 등)
@@ -17,23 +24,40 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    @Column(name = "external_id", columnDefinition = "BINARY(16)",
+            nullable = false, updatable = false, unique = true)
+    private UUID externalId;
+
     @Setter
-    private String userName;
+    @Column(name = "user_name", nullable = false)
+    private String username;
 
     @Column(nullable = false, unique = true)
     private String email;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private OAuthProvider provider;
+
+    @Column(nullable = false)
+    private String providerId;
 
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @PrePersist
+    public void assignExternalId() {
+        if (externalId == null) {
+            externalId = UUID.randomUUID();
+        }
+    }
+
     @Builder
-    public User(String userName, String email, OAuthProvider provider, Role role) {
-        this.userName = userName;
+    public User(String username, String email, OAuthProvider provider, String providerId, Role role) {
+        this.username = username;
         this.email = email;
         this.provider = provider;
+        this.providerId = providerId;
         this.role = role;
     }
 

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -8,12 +8,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_provider", columnNames = "provider"),
-                @UniqueConstraint(name = "uk_provider_id", columnNames = "provider_id")
-        }
-)
+@Table(name = "users")
 public class User extends BaseEntity {
 
     // TODO: validation 필요 (email 등)

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -8,11 +8,16 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
+@Table(name = "users",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_provider_provider_id",
+                columnNames = {"provider", "provider_id"}
+        ))
 public class User extends BaseEntity {
 
     // TODO: validation 필요 (email 등)
     // TODO: age, gender 추가 필요
+    // TODO: 차단, 탈퇴, 삭제 등 비활성화 정보 필요
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,10 +36,10 @@ public class User extends BaseEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private OAuthProvider provider;
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private String providerId;
 
     @Enumerated(EnumType.STRING)
@@ -49,6 +54,10 @@ public class User extends BaseEntity {
 
     @Builder
     public User(String username, String email, OAuthProvider provider, String providerId, Role role) {
+        if (username.isEmpty() || email.isEmpty() || provider == null || providerId.isEmpty()) {
+            throw new IllegalArgumentException("필수 필드는 null이 될 수 없습니다");
+        }
+
         this.username = username;
         this.email = email;
         this.provider = provider;

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -49,12 +49,7 @@ public class User extends BaseEntity {
     public void assignExternalId() {
         if (externalId == null) {
             try {
-                UUID uuid = UUID.randomUUID();
-                long mostSigBits = uuid.getMostSignificantBits();
-                long leastSigBits = uuid.getLeastSignificantBits();
-
-                // 시간적 지역성을 개선하기 위한 비트 재배열
-                externalId =  new UUID(leastSigBits, mostSigBits);
+                externalId = UUID.randomUUID();
             } catch (SecurityException e) {
                 externalId = new UUID(System.currentTimeMillis(), System.nanoTime());
             }

--- a/src/main/java/com/flyby/ramble/model/User.java
+++ b/src/main/java/com/flyby/ramble/model/User.java
@@ -9,6 +9,9 @@ import lombok.*;
 @Table(name = "users")
 public class User extends BaseEntity {
 
+    // TODO: validation 필요 (email 등)
+    // TODO: age, gender 추가 필요
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -21,16 +24,16 @@ public class User extends BaseEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    private Platform platform;
+    private OAuthProvider provider;
 
     @Enumerated(EnumType.STRING)
     private Role role;
 
     @Builder
-    public User(String userName, String email, Platform platform, Role role) {
+    public User(String userName, String email, OAuthProvider provider, Role role) {
         this.userName = userName;
         this.email = email;
-        this.platform = platform;
+        this.provider = provider;
         this.role = role;
     }
 

--- a/src/main/java/com/flyby/ramble/repository/UserRepository.java
+++ b/src/main/java/com/flyby/ramble/repository/UserRepository.java
@@ -1,7 +1,13 @@
 package com.flyby.ramble.repository;
 
+import com.flyby.ramble.model.OAuthProvider;
 import com.flyby.ramble.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
 }

--- a/src/main/java/com/flyby/ramble/service/UserService.java
+++ b/src/main/java/com/flyby/ramble/service/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     // TODO: 동일한 유저의 중복 생성 가능성 판단 후 수정
+    // TODO: 커스텀 예외 처리 추후 추가
     public User registerOrLogin(String email, String username, OAuthProvider provider, String providerId) {
         try {
             return userRepository.findByProviderAndProviderId(provider, providerId)
@@ -29,7 +30,7 @@ public class UserService {
                             .build()));
         } catch (DataIntegrityViolationException e) {
             return userRepository.findByProviderAndProviderId(provider, providerId)
-                    .orElseThrow(() -> new RuntimeException("예상치 못한 오류가 발생했습니다", e));
+                    .orElseThrow(() -> new IllegalArgumentException("예상치 못한 오류가 발생했습니다", e));
         }
     }
 

--- a/src/main/java/com/flyby/ramble/service/UserService.java
+++ b/src/main/java/com/flyby/ramble/service/UserService.java
@@ -1,0 +1,39 @@
+package com.flyby.ramble.service;
+
+import com.flyby.ramble.model.OAuthProvider;
+import com.flyby.ramble.model.Role;
+import com.flyby.ramble.model.User;
+import com.flyby.ramble.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User registerOrLogin(String email, String username, OAuthProvider provider, String providerId) {
+        Optional<User> optUser = userRepository.findByProviderAndProviderId(provider, providerId);
+
+        if (optUser.isEmpty()) {
+            User user = User.builder()
+                    .email(email)
+                    .username(username)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .role(Role.USER)
+                    .build();
+
+            return userRepository.save(user);
+        }
+
+        return optUser.get();
+    }
+
+
+}

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -2,3 +2,26 @@ jwt:
   secret: ${JWT_SECRET}
   issuer: ${JWT_ISSUER}
   expiration-ms: ${JWT_EXPIRATION_MS}
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            provider: google
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+              - profile
+              - email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
+            user-name-attribute: sub

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -9,19 +9,6 @@ spring:
       client:
         registration:
           google:
-            provider: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: ${GOOGLE_REDIRECT_URI}
-            authorization-grant-type: authorization_code
-            scope:
-              - openid
-              - profile
-              - email
-        provider:
-          google:
-            authorization-uri: https://accounts.google.com/o/oauth2/auth
-            token-uri: https://oauth2.googleapis.com/token
-            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
-            jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
-            user-name-attribute: sub

--- a/src/test/java/com/flyby/ramble/auth/filter/JwtFilterTest.java
+++ b/src/test/java/com/flyby/ramble/auth/filter/JwtFilterTest.java
@@ -1,5 +1,8 @@
-package com.flyby.ramble.jwt;
+package com.flyby.ramble.auth.filter;
 
+import com.flyby.ramble.auth.util.JwtUtil;
+import com.flyby.ramble.model.DeviceType;
+import com.flyby.ramble.model.OAuthProvider;
 import com.flyby.ramble.model.Role;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +50,7 @@ class JwtFilterTest {
     @Test
     void doFilterInternal_validToken() throws Exception {
         // given
-        String token = jwtUtil.createToken(userId, Role.USER, "testTenantId");
+        String token = jwtUtil.createToken(userId, Role.USER, DeviceType.ANDROID, OAuthProvider.GOOGLE, "");
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer " + token);
@@ -58,7 +61,6 @@ class JwtFilterTest {
         jwtFilter.doFilterInternal(request, response, filterChain);
 
         // then
-        // 필터 체인이 호출되었는지 확인
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         assertThat(auth).isNotNull();
         assertThat(auth.getPrincipal()).isEqualTo(userId.toString());

--- a/src/test/java/com/flyby/ramble/auth/util/JwtUtilTest.java
+++ b/src/test/java/com/flyby/ramble/auth/util/JwtUtilTest.java
@@ -38,8 +38,6 @@ class JwtUtilTest {
 
         Instant now = Instant.now();
 
-        System.out.println(token);
-
         Claims claims = jwtUtil.parseClaims(token);
         assertThat(claims.getSubject()).isEqualTo(uuid.toString());
         assertThat(claims.get("role", String.class)).isEqualTo("ROLE_" + Role.USER.name());

--- a/src/test/java/com/flyby/ramble/auth/util/JwtUtilTest.java
+++ b/src/test/java/com/flyby/ramble/auth/util/JwtUtilTest.java
@@ -1,5 +1,7 @@
-package com.flyby.ramble.jwt;
+package com.flyby.ramble.auth.util;
 
+import com.flyby.ramble.model.DeviceType;
+import com.flyby.ramble.model.OAuthProvider;
 import com.flyby.ramble.model.Role;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;
@@ -31,15 +33,19 @@ class JwtUtilTest {
     @Test
     void createToken() {
         UUID uuid = UUID.randomUUID();
-        String token = jwtUtil.createToken(uuid, Role.USER, "testTenantId");
+        String token = jwtUtil.createToken(uuid, Role.USER, DeviceType.ANDROID, OAuthProvider.GOOGLE, "1223456");
         assertThat(token).isNotNull();
 
         Instant now = Instant.now();
 
+        System.out.println(token);
+
         Claims claims = jwtUtil.parseClaims(token);
         assertThat(claims.getSubject()).isEqualTo(uuid.toString());
         assertThat(claims.get("role", String.class)).isEqualTo("ROLE_" + Role.USER.name());
-        assertThat(claims.get("tenantId", String.class)).isEqualTo("testTenantId");
+        assertThat(claims.get("deviceType", String.class)).isEqualTo(DeviceType.ANDROID.name());
+        assertThat(claims.get("provider", String.class)).isEqualTo(OAuthProvider.GOOGLE.name());
+        assertThat(claims.get("providerId", String.class)).isEqualTo("1223456");
         assertThat(claims.getIssuer()).isEqualTo("test-issuer");
         assertThat(claims.getExpiration()).isAfter(now);
         assertThat(claims.getExpiration()).isBefore(now.plusMillis(1800000));


### PR DESCRIPTION
## 요약
Google OAuth 로그인/회원가입 구현

## 상세 내용
- Google 로그인/회원가입
  1. 구글 로그인 시도
  2. 유저 없으면 생성
  3. Jwt 반환
- Apple 추가 필요

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
> #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - Google OAuth2 인증 및 OpenID Connect(OIDC) 로그인을 지원합니다.
    - OIDC 인증 성공 시 JWT 토큰이 자동으로 발급되어 응답 헤더에 포함됩니다.
    - 다양한 디바이스 타입(ANDROID, IOS, WEB)과 OAuth 제공자(GOOGLE, APPLE)를 지원합니다.
    - OAuth2 사용자 정보 동기화 및 사용자 등록/로그인 기능이 추가되었습니다.

- **버그 수정**
    - 없음

- **문서화**
    - Google OAuth2 클라이언트 등록 관련 환경 변수 및 설정 예시가 추가되었습니다.

- **리팩터링**
    - 기존 Platform 관련 필드가 OAuthProvider로 통합되고, User 엔티티에 외부 식별자 필드가 추가되었습니다.
    - 보안 설정에 OAuth2 로그인 및 OIDC 사용자 서비스, 인증 성공 핸들러가 통합되었습니다.

- **테스트**
    - JWT 생성 및 필터 관련 테스트가 새로운 구조와 필드에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->