### PR TITLE
[Fix] 안드로이드 환경에서 신고 API 호출 시 multipart/form-data 매핑 오류 수정 #56

### DIFF
--- a/src/main/java/com/flyby/ramble/report/controller/NudeDetectionController.java
+++ b/src/main/java/com/flyby/ramble/report/controller/NudeDetectionController.java
@@ -1,9 +1,13 @@
 package com.flyby.ramble.report.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flyby.ramble.report.dto.AutoNudeDetectionCommandDTO;
 import com.flyby.ramble.report.dto.AutoNudeDetectionRequestDTO;
 import com.flyby.ramble.report.service.NudeDetectionService;
-import jakarta.validation.Valid;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,15 +18,36 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Set;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class NudeDetectionController {
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
     private final NudeDetectionService nudeDetectionService;
 
     @PostMapping(value = "/auto-nude-detection", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> submitAutoNudeDetection(@Valid @RequestPart("request") AutoNudeDetectionRequestDTO requestDTO,
-                                                 @RequestPart(value = "peerVideoSnapshot", required = true) MultipartFile peerVideoSnapshot) {
+    public ResponseEntity<Void> submitAutoNudeDetection(@RequestPart("request") String requestJson,
+                                                 @RequestPart(value = "peerVideoSnapshot") MultipartFile peerVideoSnapshot) {
+
+        /**
+         * TODO 현재는 requestBody에서 신고대상자 ID를 가져오고 있으나 토큰이나 인증 정보에서 가져오도록 수정 필요
+         */
+
+        AutoNudeDetectionRequestDTO requestDTO;
+        try {
+            requestDTO = objectMapper.readValue(requestJson, AutoNudeDetectionRequestDTO.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        Set<ConstraintViolation<AutoNudeDetectionRequestDTO>> violations = validator.validate(requestDTO);
+        if (!validator.validate(requestDTO).isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+
         nudeDetectionService.requestAutoDetection(
                 AutoNudeDetectionCommandDTO.builder()
                     .userUuid(requestDTO.getUserUuid())

--- a/src/main/java/com/flyby/ramble/report/controller/ReportController.java
+++ b/src/main/java/com/flyby/ramble/report/controller/ReportController.java
@@ -1,8 +1,13 @@
 package com.flyby.ramble.report.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flyby.ramble.report.dto.ReportUserRequestDTO;
 import com.flyby.ramble.report.service.ReportService;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
+import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,16 +18,37 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Set;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class ReportController {
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
     private final ReportService reportService;
 
     @PostMapping(value = "/user-reports", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> reportByUser(@Valid @RequestPart("request") ReportUserRequestDTO requestDTO,
+    public ResponseEntity<Void> reportByUser(@RequestPart("request") String requestJson,
                                              @RequestPart(value = "peerVideoSnapshot", required = false) MultipartFile peerVideoSnapshot) {
+        /**
+         * TODO 현재는 requestBody에서 신고대상자 ID를 가져오고 있으나 토큰이나 인증 정보에서 가져오도록 수정 필요
+         */
+
+        ReportUserRequestDTO requestDTO;
+        try {
+            requestDTO = objectMapper.readValue(requestJson, ReportUserRequestDTO.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        Set<ConstraintViolation<ReportUserRequestDTO>> violations = validator.validate(requestDTO);
+        if (!validator.validate(requestDTO).isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+
         log.debug("User report request received: {}", requestDTO);
+
         reportService.reportByUser(requestDTO, peerVideoSnapshot);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }


### PR DESCRIPTION
## 요약
안드로이드 환경에서 신고 API 호출 시 발생하던 `multipart/form-data` 매핑 오류를 수정했습니다.  
JSON 데이터를 DTO로 직접 매핑하지 않고 `String`으로 수신 후 내부에서 변환 및 검증하는 방식으로 변경했습니다.

## 상세 내용
- 안드로이드 환경에서 `multipart/form-data` 요청 시 JSON이 DTO로 정상 매핑되지 않는 문제 확인
- JSON 데이터를 `String` 타입으로 수신하도록 변경
- 메소드 내부에서 `ObjectMapper` 등을 사용하여 DTO로 변환 및 유효성 검증 수행
- 웹과 안드로이드 환경에서 동일하게 동작하도록 API 매핑 로직 통일

## Issue Number
resolved #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능 없음

- 버그 수정
  - 신고/노출 감지 제출 시 입력 검증을 강화하고 JSON 파싱 오류에 대한 처리 개선으로 오류 응답의 명확성 향상

- 리팩터링
  - 신고(Report) 및 노출 감지 제출 API가 멀티파트의 ‘request’ 파트에서 JSON 문자열을 수신하도록 내부 처리 방식을 정리
  - 요청 형식은 동일하게 유지됨(멀티파트 ‘request’에 JSON, 선택적 ‘peerVideoSnapshot’ 지원)
  - 안정성과 일관성을 위한 의존성 주입 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->