### PR TITLE
[Chore] Dependabot jjwt 그룹화

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,14 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"  # "daily", "weekly", "monthly"
+      interval: "weekly"  # "daily", "weekly", "monthly"
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot"
-        update-types: [ "version-update:semver-major" ]
-    assignees:
-      - "dependabot-bot"
+    groups:
+      jjwt:
+        patterns:
+          - "io.jsonwebtoken:jjwt-*"
 
   # GitHub Actions 워크플로우 업데이트
   - package-ecosystem: "github-actions"
@@ -18,5 +19,3 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
-    assignees:
-      - "dependabot-bot"


### PR DESCRIPTION
## 요약
Dependabot jjwt 모듈 그룹화

## 상세 내용
dependabot.yml에서 다음 jjwt 모듈 그룹화
- io.jsonwebtoken:jjwt-api
- io.jsonwebtoken:jjwt-impl
- io.jsonwebtoken:jjwt-jackson

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
> #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 작업(Chores)
  * 자동 의존성 업데이트 설정을 조정했습니다: Gradle 업데이트 주기를 주간으로 변경하고, 메이저 버전 무시 규칙을 제거했으며, 자동 담당자 할당을 해제했습니다.
  * JJWT 관련 의존성을 하나의 그룹으로 묶어 일괄 업데이트하도록 구성했습니다.
  * GitHub Actions 의존성 업데이트에서도 자동 담당자 할당을 해제했습니다.
  * 사용자에게 직접 보이는 변경은 없으나, 의존성 관리가 더 신속하고 일관되게 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->