### PR TITLE
fix: application.properties 에서 오브젝트 스토리지 region 설정 추가 #71

### DIFF
--- a/src/main/java/com/flyby/ramble/common/config/MinioConfig.java
+++ b/src/main/java/com/flyby/ramble/common/config/MinioConfig.java
@@ -18,6 +18,7 @@ public class MinioConfig {
     public MinioClient minioClient() {
         return MinioClient.builder()
                 .endpoint(storageProperties.getEndpoint())
+                .region(storageProperties.getRegion())
                 .credentials(storageProperties.getCredentials().getAccessKey(), storageProperties.getCredentials().getSecretKey())
                 .build();
     }

--- a/src/main/java/com/flyby/ramble/common/config/StorageProperties.java
+++ b/src/main/java/com/flyby/ramble/common/config/StorageProperties.java
@@ -10,6 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class StorageProperties {
     private final String endpoint;
     private final String bucket;
+    private final String region;
     private final Credentials credentials;
 
     @Getter

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,6 +28,7 @@ spring:
 storage:
   endpoint: ${STORAGE_ENDPOINT}
   bucket: ${STORAGE_BUCKET}
+  region: ${STORAGE_REGION}
   credentials:
     access-key: ${STORAGE_ACCESS_KEY}
     secret-key: ${STORAGE_SECRET_KEY}


### PR DESCRIPTION
## 요약
*pplication.properties 에서 오브젝트 스토리지 region 설정이 없어 추가하였습니다.*

## 상세 내용
- *pplication.properties 에서 오브젝트 스토리지 region 설정이 없어 추가하였습니다.*

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
> fixes #71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 클라우드 스토리지 서비스의 지역(Region) 구성 지원이 추가되었습니다. 환경 변수를 통해 스토리지 지역을 설정할 수 있으며, 이를 통해 서비스가 특정 지역의 스토리지에 연결되어 동작합니다. 지역별 배포 요구사항을 더욱 유연하게 대응할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->