### PR TITLE
[Fix] 회원가입 시 Gender nullpointerexception 해결

### DIFF
--- a/src/main/java/com/flyby/ramble/oauth/service/GooglePeopleApiService.java
+++ b/src/main/java/com/flyby/ramble/oauth/service/GooglePeopleApiService.java
@@ -91,7 +91,7 @@ public class GooglePeopleApiService {
             return new GooglePersonInfo(Gender.from(gender), birthDate);
         } catch (Exception e) {
             log.error("Failed to parse person info response", e);
-            return new GooglePersonInfo(null, null);
+            return new GooglePersonInfo(Gender.UNKNOWN, null);
         }
     }
 


### PR DESCRIPTION
## 요약
Google OAuth2 회원가입 시 birthday, gender 미동의 시 (scopes의 birthday, gender가 없을 시) Gender를 Null로 저장하는 문제 해결

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
> #78


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Google People API에서 개인 정보 조회 시 데이터가 없거나 조회 실패한 경우 더 견고한 처리를 제공합니다. 이제 null 값만 반환하지 않고 기본값을 설정하여 시스템 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->